### PR TITLE
chore: pin reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/check_and_co.yaml
+++ b/.github/workflows/check_and_co.yaml
@@ -7,24 +7,33 @@ on:
     branches:
       - main
       - master
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 name: All actions
 jobs:
   check-current-version:
     name: Check current version
-    uses: >-
-      NovoNordisk-OpenSource/r.workflows/.github/workflows/check_current_version.yaml@main
+    permissions:
+      contents: read
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/check_current_version.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
   pkgdown:
     name: Pkgdown site
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/pkgdown.yaml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/pkgdown.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
   coverage:
     name: Coverage report
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/coverage.yaml@main
-    secrets: inherit
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/coverage.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       use_codecov: true
   megalinter:
     name: Megalinter
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/megalinter.yaml@main
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/megalinter.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: connector.sharepoint
 Title: 'Microsoft SharePoint' Interface for the 'connector' Package
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: c(
     person("Vladimir", "Obucina", , "vlob@novonordisk.com", role = c("aut", "cre"),
            comment = c(ORCID = "0009-0008-2608-2661")),


### PR DESCRIPTION
## Summary
Pin all reusable workflows called from `check_and_co.yaml` to the v0.1.0 tag SHA of `NovoNordisk-OpenSource/r.workflows`, address zizmor findings raised by MegaLinter, and add Dependabot config to keep the pins current.

## Changes Made
- Pin `check_current_version`, `pkgdown`, `coverage`, and `megalinter` reusable workflows to `fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3` (v0.1.0).
- Replace workflow-level `contents: write` and `pull-requests: write` with `permissions: {}` and set the minimum required permissions per job.
- Replace `secrets: inherit` on the coverage job with an explicit `CODECOV_TOKEN` pass-through.
- Add `.github/dependabot.yml` for weekly `github-actions` updates with `chore` commit-message prefix.

## Testing
- MegaLinter / zizmor findings resolved.
- Existing workflows continue to run on push and pull_request against `main`/`master`.

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
